### PR TITLE
Add github action to assert branch naming

### DIFF
--- a/.github/workflows/assert_branch_naming_convention.yaml
+++ b/.github/workflows/assert_branch_naming_convention.yaml
@@ -9,6 +9,6 @@ jobs:
     steps:
       - uses: deepakputhraya/action-branch-name@master
         with:
-          regex: (feature|fix)\/\w*
+          regex: \/\w*
           allowed_prefixes: feature,fix
           ignore: master

--- a/.github/workflows/assert_branch_naming_convention.yaml
+++ b/.github/workflows/assert_branch_naming_convention.yaml
@@ -1,14 +1,14 @@
 name: Assert Branch Naming Convention
 
-on:
-  pull_request
+on: pull_request
 
 jobs:
-  naming-rules:
+  branch-naming-rules:
     runs-on: ubuntu-latest
 
     steps:
       - uses: deepakputhraya/action-branch-name@master
         with:
-          regex: /(feature|hotfix)\/\w*/gm
+          regex: (feature|fix)\/\w*\gm
+          allowed_prefixes: feature,fix
           ignore: master

--- a/.github/workflows/assert_branch_naming_convention.yaml
+++ b/.github/workflows/assert_branch_naming_convention.yaml
@@ -1,0 +1,14 @@
+name: Assert Branch Naming Convention
+
+on:
+  pull_request
+
+jobs:
+  naming-rules:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: deepakputhraya/action-branch-name@master
+        with:
+          regex: /(feature|hotfix)\/\w*/gm
+          ignore: master

--- a/.github/workflows/assert_branch_naming_convention.yaml
+++ b/.github/workflows/assert_branch_naming_convention.yaml
@@ -9,6 +9,6 @@ jobs:
     steps:
       - uses: deepakputhraya/action-branch-name@master
         with:
-          regex: /(feature|fix)\/\w*/gm
+          regex: (feature|fix)\/\w*
           allowed_prefixes: feature,fix
           ignore: master

--- a/.github/workflows/assert_branch_naming_convention.yaml
+++ b/.github/workflows/assert_branch_naming_convention.yaml
@@ -9,6 +9,6 @@ jobs:
     steps:
       - uses: deepakputhraya/action-branch-name@master
         with:
-          regex: (feature|fix)\/\w*\gm
+          regex: /(feature|fix)\/\w*/gm
           allowed_prefixes: feature,fix
           ignore: master

--- a/.github/workflows/on_pr_targeting_master.yaml
+++ b/.github/workflows/on_pr_targeting_master.yaml
@@ -12,8 +12,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
+      - uses: actions/checkout@v3
+
+      - name: Build
+        run: cargo build --verbose
+
+      - name: Test
+        run: cargo test --verbose


### PR DESCRIPTION
- asserts that branches that are submitting PRs have a certain regex that they must follow
- only kicks off on PRs